### PR TITLE
Cleanup dependencies

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,12 +10,37 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v1
-    - uses: php-actions/composer@v1 # or alternative dependency management
+    strategy:
+      matrix:
+        php-version:
+          - "7.3"
+          - "7.4"
+          - "8.0"
+        dependencies:
+          - "highest"
+          - "lowest"
 
-    # Run unit
-    - name: PHPUnit (php-actions)
-      uses: php-actions/phpunit@v1
-      with:
-        config: phpunit.xml
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: pcov
+          ini-values: memory_limit=-1
+          tools: composer:v2
+
+      - name: "Install dependencies (highest)"
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: "composer update --prefer-dist --no-interaction --no-progress"
+
+      - name: "Install dependencies (lowest)"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: "composer update --prefer-lowest --prefer-dist --no-interaction --no-progress"
+
+      - name: "Run PHPUnit"
+        run: "vendor/bin/phpunit"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 build/
 target/
 .php_cs.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lamoda/codeception-email-mailhog",
+    "name": "oqq/codeception-email-mailhog",
     "description": "Provides test helpers for Codeception when testing email functionality with MailHog",
     "license": "MIT",
     "authors": [
@@ -10,18 +10,23 @@
         {
             "name": "Lamoda developers",
             "homepage": "https://tech.lamoda.ru/"
+        },
+        {
+            "name": "Eric Braun",
+            "email": "eb@oqq.be"
         }
     ],
     "require": {
-        "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.1",
-        "ext-json": "*"
+        "php": "7.3.* | 7.4.* | 8.0.*",
+        "ext-json": "*",
+        "ericmartel/codeception-email": "^1.0.3",
+        "guzzlehttp/guzzle": "^6.1 | ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
         "codeception/codeception": "^4.0",
-        "ericmartel/codeception-email": "^1.0",
-        "friendsofphp/php-cs-fixer": "^2.15.0"
+        "friendsofphp/php-cs-fixer": "^2.15",
+        "phpunit/phpunit": "^8.0",
+        "roave/security-advisories": "dev-master"
     },
     "suggest": {
         "ext-iconv": "Will be used as a mime decoder (iconv_mime_decode)",
@@ -36,5 +41,8 @@
         "psr-4": {
             "Codeception\\Module\\Tests\\": "tests"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
- remove support for php 7.2
- add explicit support for php 7.3; 7.4; 8.0
- add support for guzzle ^7.0
- add requirement for ericmartel/codeception-email, as this library is used in code
- update github actions to test all explicit supported dependencies