### PR TITLE
Add support for PHP 8.2

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         php-version:
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
           - "lowest"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "8.1.*",
+        "php": "8.1.* | 8.2.*",
         "ext-json": "*",
         "ericmartel/codeception-email": "^1.0.3",
         "guzzlehttp/guzzle": "^6.1 | ^7.0"


### PR DESCRIPTION
The codebase seems to be compatible with PHP 8.2 already, so this PR only widens the dependency constraint and adds PHP 8.2 to the test matrix.